### PR TITLE
fix: parameter for luadoc should start with triple hyphens

### DIFF
--- a/lua/nvim-tree-docs/specs/lua/luadoc.lua
+++ b/lua/nvim-tree-docs/specs/lua/luadoc.lua
@@ -60,7 +60,7 @@ module.processors.param = {
     local result = {}
     for param in context.iter(context.parameters) do
       local name = context["get-text"](param.entry.name)
-      table.insert(result, "-- @param " .. name .. " The " .. name)
+      table.insert(result, "--- @param " .. name .. " The " .. name)
     end
     return result
   end,

--- a/test/e2e/lua.test.lua
+++ b/test/e2e/lua.test.lua
@@ -16,8 +16,8 @@ describe("lua luadoc", function()
 
     assert.same({
       "--- Description",
-      "-- @param a The a",
-      "-- @param b The b",
+      "--- @param a The a",
+      "--- @param b The b",
       "local function sample(a, b)",
       "  return a + b",
       "end",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Lua documentation comments for parameter annotations to use three dashes (---) instead of two (--).
* **Tests**
  * Adjusted test expectations to reflect the updated Lua documentation comment style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->