### PR TITLE
ci: use magic-cache-action

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -97,6 +97,7 @@ jobs:
         uses: ./.github/actions/setup-nix
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: DeterminateSystems/magic-nix-cache-action@565684385bcd71bad329742eefe8d12f2e765b39 # v13
       - run: nix run .#test
   status-check:
     timeout-minutes: 5


### PR DESCRIPTION
`test` needs to build tree-sitter parsers.

This is expected to be a huge size so we enable only on `test` step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI workflow by adding a cache priming step before tests, improving pipeline speed and reliability.
* **Tests**
  * Adjusted test job sequence to include cache preparation, reducing test run time and potential flakiness.
* **Notes**
  * No changes to application features or behavior for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->