### PR TITLE
chore: specify `forkProcessing`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,4 +3,5 @@
   extends: [
     "github>Omochice/personal-renovate-config",
   ],
+  forkProcessing: "enabled",
 }


### PR DESCRIPTION
Make be able to work renovate on forked repository.

Reference-to: https://docs.renovatebot.com/configuration-options/#forkprocessing
