### PR TITLE
test: use scratch buffer instead

### DIFF
--- a/test/e2e/javascript.test.lua
+++ b/test/e2e/javascript.test.lua
@@ -1,6 +1,6 @@
 describe("javascript jsdoc", function()
   it("should generate jsdoc for function", function()
-    local bufnr = vim.api.nvim_create_buf(false, false)
+    local bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(bufnr)
     vim.bo.filetype = "javascript"
     local contents = {
@@ -29,7 +29,7 @@ describe("javascript jsdoc", function()
   end)
 
   it("should generate jsdoc for variable", function()
-    local bufnr = vim.api.nvim_create_buf(false, false)
+    local bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(bufnr)
     vim.bo.filetype = "javascript"
     local contents = {
@@ -50,7 +50,7 @@ describe("javascript jsdoc", function()
   end)
 
   it("should generate jsdoc for class", function()
-    local bufnr = vim.api.nvim_create_buf(false, false)
+    local bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(bufnr)
     vim.bo.filetype = "javascript"
     local contents = {
@@ -76,7 +76,7 @@ describe("javascript jsdoc", function()
   end)
 
   it("should generate jsdoc for method", function()
-    local bufnr = vim.api.nvim_create_buf(false, false)
+    local bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(bufnr)
     vim.bo.filetype = "javascript"
     local contents = {

--- a/test/e2e/javascript.test.lua
+++ b/test/e2e/javascript.test.lua
@@ -1,8 +1,12 @@
 describe("javascript jsdoc", function()
-  it("should generate jsdoc for function", function()
-    local bufnr = vim.api.nvim_create_buf(false, true)
+  ---@type integer
+  local bufnr
+  before_each(function()
+    bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(bufnr)
-    vim.bo.filetype = "javascript"
+    vim.bo[bufnr].filetype = "javascript"
+  end)
+  it("should generate jsdoc for function", function()
     local contents = {
       "function sample(a, b) {",
       "  return a + b;",
@@ -29,9 +33,6 @@ describe("javascript jsdoc", function()
   end)
 
   it("should generate jsdoc for variable", function()
-    local bufnr = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_set_current_buf(bufnr)
-    vim.bo.filetype = "javascript"
     local contents = {
       "const sample = 42;",
     }
@@ -50,9 +51,6 @@ describe("javascript jsdoc", function()
   end)
 
   it("should generate jsdoc for class", function()
-    local bufnr = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_set_current_buf(bufnr)
-    vim.bo.filetype = "javascript"
     local contents = {
       "class A {",
       "  foo = 42;",
@@ -76,9 +74,6 @@ describe("javascript jsdoc", function()
   end)
 
   it("should generate jsdoc for method", function()
-    local bufnr = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_set_current_buf(bufnr)
-    vim.bo.filetype = "javascript"
     local contents = {
       "class A {",
       "  foo = 42;",

--- a/test/e2e/lua.test.lua
+++ b/test/e2e/lua.test.lua
@@ -1,8 +1,12 @@
 describe("lua luadoc", function()
-  it("should generate lua docstring", function()
-    local bufnr = vim.api.nvim_create_buf(false, true)
+  ---@type integer
+  local bufnr
+  before_each(function()
+    bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(bufnr)
-    vim.bo.filetype = "lua"
+    vim.bo[bufnr].filetype = "lua"
+  end)
+  it("should generate lua docstring", function()
     local contents = {
       "local function sample(a, b)",
       "  return a + b",
@@ -25,9 +29,6 @@ describe("lua luadoc", function()
   end)
 
   it("should generate luadoc for variable", function()
-    local bufnr = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_set_current_buf(bufnr)
-    vim.bo.filetype = "lua"
     local contents = {
       "local sample = 42",
     }

--- a/test/e2e/lua.test.lua
+++ b/test/e2e/lua.test.lua
@@ -1,6 +1,6 @@
 describe("lua luadoc", function()
   it("should generate lua docstring", function()
-    local bufnr = vim.api.nvim_create_buf(false, false)
+    local bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(bufnr)
     vim.bo.filetype = "lua"
     local contents = {
@@ -25,7 +25,7 @@ describe("lua luadoc", function()
   end)
 
   it("should generate luadoc for variable", function()
-    local bufnr = vim.api.nvim_create_buf(false, false)
+    local bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(bufnr)
     vim.bo.filetype = "lua"
     local contents = {

--- a/test/e2e/typescript.test.lua
+++ b/test/e2e/typescript.test.lua
@@ -1,6 +1,6 @@
 describe("typescript jsdoc", function()
   it("should generate typescript jsdoc", function()
-    local bufnr = vim.api.nvim_create_buf(false, false)
+    local bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(bufnr)
     vim.bo.filetype = "typescript"
     local contents = {
@@ -29,7 +29,7 @@ describe("typescript jsdoc", function()
   end)
 
   it("should generate jsdoc for variable", function()
-    local bufnr = vim.api.nvim_create_buf(false, false)
+    local bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(bufnr)
     vim.bo.filetype = "typescript"
     local contents = {
@@ -50,7 +50,7 @@ describe("typescript jsdoc", function()
   end)
 
   it("should generate jsdoc for class", function()
-    local bufnr = vim.api.nvim_create_buf(false, false)
+    local bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(bufnr)
     vim.bo.filetype = "typescript"
     local contents = {
@@ -75,7 +75,7 @@ describe("typescript jsdoc", function()
   end)
 
   it("should generate jsdoc for method", function()
-    local bufnr = vim.api.nvim_create_buf(false, false)
+    local bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(bufnr)
     vim.bo.filetype = "typescript"
     local contents = {

--- a/test/e2e/typescript.test.lua
+++ b/test/e2e/typescript.test.lua
@@ -1,8 +1,12 @@
 describe("typescript jsdoc", function()
-  it("should generate typescript jsdoc", function()
-    local bufnr = vim.api.nvim_create_buf(false, true)
+  ---@type integer
+  local bufnr
+  before_each(function()
+    bufnr = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_set_current_buf(bufnr)
-    vim.bo.filetype = "typescript"
+    vim.bo[bufnr].filetype = "typescript"
+  end)
+  it("should generate typescript jsdoc", function()
     local contents = {
       "function sample(a: string, b: number): string {",
       "  return a + b;",
@@ -29,9 +33,6 @@ describe("typescript jsdoc", function()
   end)
 
   it("should generate jsdoc for variable", function()
-    local bufnr = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_set_current_buf(bufnr)
-    vim.bo.filetype = "typescript"
     local contents = {
       "const sample = 42;",
     }
@@ -50,9 +51,6 @@ describe("typescript jsdoc", function()
   end)
 
   it("should generate jsdoc for class", function()
-    local bufnr = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_set_current_buf(bufnr)
-    vim.bo.filetype = "typescript"
     local contents = {
       "class A {",
       "  foo = 42;",
@@ -75,9 +73,6 @@ describe("typescript jsdoc", function()
   end)
 
   it("should generate jsdoc for method", function()
-    local bufnr = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_set_current_buf(bufnr)
-    vim.bo.filetype = "typescript"
     local contents = {
       "class A {",
       "  foo = 42;",


### PR DESCRIPTION
Prevent to fail test by error about swap file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized end-to-end tests (JS, TS, Lua) to use a shared scratch buffer via a before_each setup.
  * Introduced a typed local buffer handle and moved buffer creation/initialization out of individual tests.
  * Filetype is now assigned per-buffer for each test run; subsequent tests reuse the shared buffer.
  * No user-facing behavior changes; improvements target test isolation and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->