### PR TITLE
ci: specify renovate environment for update job

### DIFF
--- a/.github/workflows/update-nvfetcher.yml
+++ b/.github/workflows/update-nvfetcher.yml
@@ -25,6 +25,7 @@ jobs:
     timeout-minutes: 10
     needs: list-packages
     runs-on: ubuntu-latest
+    environment: renovate
     permissions: {}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Add `environment: renovate` to the `update` job in the update-nvfetcher workflow so that it can access secrets stored in the GitHub `renovate` environment.

## Details

The `update` job references `secrets.RENOVATE_APP_ID` and `secrets.RENOVATE_PRIVATE_KEY`, which are stored in the `renovate` GitHub environment. Without specifying `environment: renovate` on the job, these secrets are not accessible.

## Confirmation

- Verify the workflow YAML syntax is valid
- Confirm the `update` job has `environment: renovate` set
- Run manually via workflow_dispatch to verify nvfetcher updates work correctly

## Limitation

No known limitations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->