### PR TITLE
refactor: reduce unused nvim-treesitter

### DIFF
--- a/_sources/generated.json
+++ b/_sources/generated.json
@@ -40,26 +40,5 @@
             "type": "github"
         },
         "version": "5e6e317a43c9d315daa4f211939b973f712b77be"
-    },
-    "nvim-treesitter": {
-        "cargoLock": null,
-        "date": "2026-03-07",
-        "extract": null,
-        "name": "nvim-treesitter",
-        "passthru": null,
-        "pinned": false,
-        "src": {
-            "deepClone": false,
-            "fetchSubmodules": false,
-            "leaveDotGit": false,
-            "name": null,
-            "owner": "nvim-treesitter",
-            "repo": "nvim-treesitter",
-            "rev": "5cb05e1b0fa3c469958a2b26f36b3fe930af221c",
-            "sha256": "sha256-C2LcXM+J+1aJ0RGsIXpRRkWbeqRN00kWWhfkyBqgY2M=",
-            "sparseCheckout": [],
-            "type": "github"
-        },
-        "version": "5cb05e1b0fa3c469958a2b26f36b3fe930af221c"
     }
 }

--- a/_sources/generated.nix
+++ b/_sources/generated.nix
@@ -30,16 +30,4 @@
     };
     date = "2026-02-21";
   };
-  nvim-treesitter = {
-    pname = "nvim-treesitter";
-    version = "5cb05e1b0fa3c469958a2b26f36b3fe930af221c";
-    src = fetchFromGitHub {
-      owner = "nvim-treesitter";
-      repo = "nvim-treesitter";
-      rev = "5cb05e1b0fa3c469958a2b26f36b3fe930af221c";
-      fetchSubmodules = false;
-      sha256 = "sha256-C2LcXM+J+1aJ0RGsIXpRRkWbeqRN00kWWhfkyBqgY2M=";
-    };
-    date = "2026-03-07";
-  };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -103,27 +103,10 @@
           };
 
         sources = pkgs.callPackage ./_sources/generated.nix { };
-        nvim-treesitter-raw = pkgs.stdenvNoCC.mkDerivation {
-          inherit (sources.nvim-treesitter) pname version src;
-          doBuild = false;
-          buildPhase = ":";
-          installPhase = ''
-            runHook preInstall
-            mkdir -p $out
-            cp -r . $out/
-            runHook postInstall
-          '';
-          meta = {
-            platforms = pkgs.lib.platforms.all;
-          };
-        };
         nvim-treesitter = (
           pkgs.symlinkJoin {
             name = "nvim-treesitter";
-            paths = [
-              nvim-treesitter-raw
-            ]
-            ++ pkgs.vimPlugins.nvim-treesitter.withAllGrammars.dependencies;
+            paths = pkgs.vimPlugins.nvim-treesitter.withAllGrammars.dependencies;
           }
         );
         mini-test = pkgs.stdenvNoCC.mkDerivation {

--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -7,8 +7,3 @@ src.branch = "master"
 fetch.github = "nvim-mini/mini.test"
 src.git = "https://github.com/nvim-mini/mini.test"
 src.branch = "main"
-
-[nvim-treesitter]
-fetch.github = "nvim-treesitter/nvim-treesitter"
-src.git = "https://github.com/nvim-treesitter/nvim-treesitter"
-src.branch = "main"


### PR DESCRIPTION
parsers and queries are installed by nix.

We dont need to use nvim-treesitter for test dependencies.

So we omit its.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed `nvim-treesitter` source entry from configuration files.
  * Simplified the build process for `nvim-treesitter` by directly using pre-built dependencies instead of custom derivation handling.
  * Minor configuration cleanup and whitespace adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->